### PR TITLE
Update JH dependencies 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 kubernetes==9.0.1
-jupyterhub==1.0.0
-#jupyterhub-kubespawner==0.10.1
-git+https://github.com/jupyterhub/kubespawner.git@a945ef01410867b39e0c174d362a8702bbaa15e9#egg=jupyterhub-kubespawner
+jupyterhub==1.1.0
+jupyterhub-kubespawner==0.12.0
 git+https://github.com/jupyterhub/wrapspawner.git@5f2b7075f77d0c1c49066682a8e8adad0dab76db
 jupyterhub-tmpauthenticator==0.6
 oauthenticator==0.9.0


### PR DESCRIPTION
~These were originally set in jupyterhub_config-workspace only, but they'd be useful even for the default installation. In addition Open Data Hub depends on `OPENSHIFT_URL` to be set for OAuth, so it makes sense to set them always~

There is a PR against oauthenticator (https://github.com/jupyterhub/oauthenticator/pull/363) which fixes some of the issues with OpenShift. Leaving this repo without changes and I'll install the updated version of oauthenticator in jupyterhub-odh (jupyterhub-ocp-oauth)