### PR TITLE
Use ubi7 based Python image to avoid missing psql error

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,7 +1,7 @@
 check:
   - thoth-build
 build:
-  base-image: "quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.15.0"
+  base-image: "registry.access.redhat.com/ubi7/python-36"
   build-stratergy: "Source"
   registry: "quay.io"
   registry-org: "odh-jupyterhub"


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

The ubi8 based images are missing `psql` command, switching back to ubi7 for the time being. We'll probably have to create a new base image in the future

## Description

<!--- Describe your changes in detail -->
