### PR TITLE
Update python kubernetes dependency==10.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kubernetes==9.0.1
+kubernetes==10.1.0
 jupyterhub==1.1.0
 jupyterhub-kubespawner==0.12.0
 git+https://github.com/jupyterhub/wrapspawner.git@5f2b7075f77d0c1c49066682a8e8adad0dab76db


### PR DESCRIPTION
Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

## This introduces a breaking change

- [X] Yes
- [ ] No

The update to the kubernetes package may affect functionality in additional libraries that `import kubernetes`

## This Pull Request implements
Update and pin the kubernetes python library to 10.1.0 to match the install requirements for `jupyterhub-kubespawner==0.12.0`

## Description
Resolve a dependency failure with `jupyterhub-kubespwaner` and `kubernetes` packages that is blocking `v3.5.1` builds

Failure output from running `s2i build . registry.access.redhat.com/ubi8/python-36 jupyterhub-quickstart:v3.5.1`
```
...
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of jupyterhub to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of kubernetes to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of wrapspawner to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r /tmp/src/requirements.txt (line 3) and kubernetes==9.0.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested kubernetes==9.0.1
    jupyterhub-kubespawner 0.12.0 depends on kubernetes>=10.1.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
error: build error: error building at STEP "RUN /tmp/scripts/assemble": error while running runtime: exit status 1
```